### PR TITLE
Added pub and priv to celBlockCmd keywords

### DIFF
--- a/syntax/cadence.vim
+++ b/syntax/cadence.vim
@@ -8,7 +8,7 @@ if exists("b:current_syntax")
 endif
 
 " Keywords
-syn keyword celBlockCmd         access all import contract return init size event interface struct
+syn keyword celBlockCmd         access all import contract return init size event interface struct pub priv
 syn keyword celBlockSelf        self
 syn keyword celBlockVar         let var nextgroup=celVarStr skipwhite
 syn keyword celBlockFun         fun


### PR DESCRIPTION
Hello, 

Thank you for creating this vim plugin. I noticed that the `pub` and `priv`  access control keywords were missing so I added them to the `celBlockCmd` keywords. 

More about access control keywords [here](https://docs.onflow.org/cadence/language/access-control).

It's a small PR, but it's honest work! :smile: 